### PR TITLE
Fixes for issues highlighted in #175

### DIFF
--- a/src/class-options.php
+++ b/src/class-options.php
@@ -36,7 +36,7 @@ class Options {
 
 		if ( ! $ms_only && ! empty( $_ENV[ $sysname ] ) ) {
 			return (object) [
-				'value'  => $_ENV[ $sysname ],
+				'value'  => sanitize_text_field( $_ENV[ $sysname ] ),
 				'source' => 'ENV',
 			];
 		} elseif ( ! $ms_only && defined( $sysname ) ) {

--- a/src/settings/class-multisite.php
+++ b/src/settings/class-multisite.php
@@ -60,7 +60,14 @@ class Multisite extends Settings {
 	 * Initialises the settings implementation.
 	 */
 	public function network_settings_init() {
-		register_setting( 'wpsimplesmtp_smtp_ms', 'wpssmtp_smtp_ms' );
+		register_setting(
+			'wpsimplesmtp_smtp_ms',
+			'wpssmtp_smtp_ms',
+			array(
+				'type'              => 'array',
+				'sanitize_callback' => array( $this, 'sanitize_smtp_settings' ),
+			)
+		);
 
 		add_settings_section(
 			'wpsimplesmtp_ms_adminaccess_section',
@@ -150,7 +157,7 @@ class Multisite extends Settings {
 		?>
 		<div class="wrap">
 			<h1><?php esc_html_e( 'Network Mail', 'simple-smtp' ); ?></h1>
-			<form action='edit.php?action=wpsimplesmtpms' method='post'>	
+			<form action='edit.php?action=wpsimplesmtpms' method='post'>
 				<?php
 				wp_nonce_field( 'simple-smtp-ms' );
 				do_settings_sections( 'wpsimplesmtp_smtp_ms' );
@@ -165,7 +172,7 @@ class Multisite extends Settings {
 	 * Retrieves the settings page when the administrator has sent changed settings.
 	 */
 	public function update_network_settings() {
-		if ( isset( $_REQUEST['_wpnonce'] ) && ! wp_verify_nonce( sanitize_key( $_REQUEST['_wpnonce'] ), 'simple-smtp-ms' ) ) {
+		if ( ! isset( $_REQUEST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( $_REQUEST['_wpnonce'] ), 'simple-smtp-ms' ) ) {
 			wp_die( esc_attr_e( 'Your nonce key has expired.', 'simple-smtp' ) );
 		}
 

--- a/src/settings/class-settings.php
+++ b/src/settings/class-settings.php
@@ -305,4 +305,53 @@ class Settings {
 			return 'wpsmtp-badge info';
 		}
 	}
+
+	/**
+	 * Sanitizes and validates SMTP settings input.
+	 *
+	 * @param array $input Associative array of SMTP settings, potentially
+	 *                     containing keys: 'host', 'port', 'auth', 'user', 'pass',
+	 *                     'from', 'fromname', 'sec', 'noverifyssl', 'disable', 'log'.
+	 *
+	 * @return array Sanitized and validated SMTP settings ready for storage.
+	 */
+	public function sanitize_smtp_settings( $input ) {
+		$output = array();
+
+		if ( ! empty( $input['host'] ) ) {
+			$output['host'] = sanitize_text_field( wp_unslash( $input['host'] ) );
+		}
+		if ( ! empty( $input['port'] ) ) {
+			$output['port'] = (int) $input['port'];
+		}
+		if ( isset( $input['auth'] ) ) {
+			$output['auth'] = (int) $input['auth'];
+		}
+		if ( ! empty( $input['user'] ) ) {
+			$output['user'] = sanitize_text_field( wp_unslash( $input['user'] ) );
+		}
+		if ( ! empty( $input['pass'] ) ) {
+			$output['pass'] = sanitize_text_field( wp_unslash( $input['pass'] ) );
+		}
+		if ( ! empty( $input['from'] ) ) {
+			$output['from'] = sanitize_email( wp_unslash( $input['from'] ) );
+		}
+		if ( ! empty( $input['fromname'] ) ) {
+			$output['fromname'] = sanitize_text_field( wp_unslash( $input['fromname'] ) );
+		}
+		if ( ! empty( $input['sec'] ) ) {
+			$output['sec'] = sanitize_text_field( wp_unslash( $input['sec'] ) );
+		}
+		if ( isset( $input['noverifyssl'] ) ) {
+			$output['noverifyssl'] = (int) $input['noverifyssl'];
+		}
+		if ( isset( $input['disable'] ) ) {
+			$output['disable'] = (int) $input['disable'];
+		}
+		if ( isset( $input['log'] ) ) {
+			$output['log'] = (int) $input['log'];
+		}
+
+		return $output;
+	}
 }

--- a/src/settings/class-singular.php
+++ b/src/settings/class-singular.php
@@ -143,7 +143,14 @@ class Singular extends Settings {
 	 * Initialises the settings implementation.
 	 */
 	public function settings_init() {
-		register_setting( 'wpsimplesmtp_smtp', 'wpssmtp_smtp' );
+		register_setting(
+			'wpsimplesmtp_smtp',
+			'wpssmtp_smtp',
+			array(
+				'type'              => 'array',
+				'sanitize_callback' => array( $this, 'sanitize_smtp_settings' ),
+			)
+		);
 
 		add_settings_section(
 			'wpsimplesmtp_smtp_section',


### PR DESCRIPTION
Issue here https://github.com/soup-bowl/simple-smtp/issues/175

Reviewed and implemented fixes based on feedback from plugin review, also validated fixes using https://wordpress.org/plugins/plugin-check/

- https://github.com/soup-bowl/simple-smtp/issues/178 fixed by adding a helper function that sanitises each field in the settings array in src/settings/class-settings.php and calling on instances of `register_setting` where needed
- https://github.com/soup-bowl/simple-smtp/issues/179 fixed by amending logic in if check so it dies if the nonce is not set
- https://github.com/soup-bowl/simple-smtp/issues/180 fixed by sanitising each email recipient 